### PR TITLE
Fix string interpolation's punctuation captures

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -3280,15 +3280,10 @@
 												</dict>
 											</array>
 										</dict>
-										<key>5</key>
-										<dict>
-											<key>name</key>
-											<string>punctuation.section.embedded.end.swift</string>
-										</dict>
 										<key>6</key>
 										<dict>
 											<key>name</key>
-											<string>source.swift</string>
+											<string>punctuation.section.embedded.end.swift</string>
 										</dict>
 									</dict>
 									<key>match</key>


### PR DESCRIPTION
The `punctuation.section.embedded.end.swift` scope was capturing the wrong group (of parens in the regex), causing the ending `)` to not be highlighted.

I removed the `source.swift` capture from group 6 — I wasn't sure the point of this? Perhaps I am missing something.
