### PR TITLE
Allow #expressions in meta.parameter-clause.swift

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -3280,10 +3280,15 @@
 												</dict>
 											</array>
 										</dict>
-										<key>6</key>
+										<key>5</key>
 										<dict>
 											<key>name</key>
 											<string>punctuation.section.embedded.end.swift</string>
+										</dict>
+										<key>6</key>
+										<dict>
+											<key>name</key>
+											<string>source.swift</string>
 										</dict>
 									</dict>
 									<key>match</key>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -2212,7 +2212,7 @@
 							<array>
 								<dict>
 									<key>include</key>
-									<string>#available-types</string>
+									<string>#expressions</string>
 								</dict>
 								<dict>
 									<key>match</key>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -3280,15 +3280,10 @@
 												</dict>
 											</array>
 										</dict>
-										<key>5</key>
-										<dict>
-											<key>name</key>
-											<string>punctuation.section.embedded.end.swift</string>
-										</dict>
 										<key>6</key>
 										<dict>
 											<key>name</key>
-											<string>source.swift</string>
+											<string>punctuation.section.embedded.end.swift</string>
 										</dict>
 									</dict>
 									<key>match</key>


### PR DESCRIPTION
I couldn't find your `fixes` branch and this one had the most recent activity, so I just chose it.. 😎

I ran into this edge case earlier today:

![screen shot 2016-09-30 at 11 17 18 pm](https://cloud.githubusercontent.com/assets/7366232/19011708/3d3e5e7a-8764-11e6-8773-0c85a08d1dad.png)

Function initializers (i.e. I am making a distinction from a `function-call`) include `#parameter-clause`, whose pattern doesn't allow for literals to be matched — it only matches `#available-types`, and _then_ literals _after_ the `type = literal` syntax.

The picture shows a `String`, but this breaks for any literal.

I changed it to include `#expressions` instead of `#available-types` and this appears to be a fix. 

![screen shot 2016-09-30 at 11 17 37 pm](https://cloud.githubusercontent.com/assets/7366232/19011727/bb789184-8764-11e6-96bd-1f2f578283c3.png)

You probably know better than I do if this breaks more than it fixes, but I thought it was worth mentioning.
